### PR TITLE
Add req-id in addition to correlationId to match bunyan standard + hydrow tablet software

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 node_modules
+.idea/
 
 ~*
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 node_modules
 .idea/
+.npmrc
 
 ~*
 *~

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# `@eropple/nestjs-bunyan` #
-[![npm version](https://badge.fury.io/js/%40eropple%2Fnestjs-bunyan.svg)](https://badge.fury.io/js/%40eropple%2Fnestjs-bunyan)
+# `@hydrow/nestjs-bunyan` #
+[![npm version](https://badge.fury.io/js/%40eropple%2Fnestjs-bunyan.svg)](https://npm.ops.hydrow-internal.net/#/detail/@hydrow/nestjs-bunyan)
 
 This package contains a module to provide Bunyan logging across a NestJS
 application. It supports full request-specific logging by providing a
@@ -7,6 +7,11 @@ request-scoped Bunyan logger in the dependency injector and includes an
 in/out interceptor for recording request data and request timing.
 
 ## Recent Changes ##
+### 0.5.8 ###
+- Added the `req-id` prop to the request-logger output, alongside
+  `correlationId`, with the same value, in keeping with the Bunyan standard,
+  and to avoid a breaking change.
+
 ### 0.5.7 ###
 - Added `postRequestCreate` as a logging option. This allows you to decore
   the request logger with fields (by setting them into `logger.fields`, see

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydrow/nestjs-bunyan",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Module and tooling for request-scoped Bunyan logging in NestJS.",
   "main": "dist",
   "author": "Ed Ropple",

--- a/sample.npmrc
+++ b/sample.npmrc
@@ -1,0 +1,12 @@
+# To fetch packages, you'll need to log into our NPM registry at:
+#
+# https://npm.ops.hydrow-internal.net (the 'https' is not optional!)
+#
+# and perform a login with GitHub. The header on our NPM registry will then
+# include a couple of `npm config set` commands. You'll want to either run
+# those globally, in order to log in for all projects/uses, or copy this
+# file to PROJECT_ROOT/.npmrc and fill out the auth token below.
+
+//npm.ops.hydrow-internal.net/:_authToken="NPM_OPS_TOKEN_HERE"
+//npm.ops.hydrow-internal.net/:always-auth=true
+registry=https://npm.ops.hydrow-internal.net

--- a/src/logging.module.ts
+++ b/src/logging.module.ts
@@ -43,7 +43,7 @@ export class LoggingModule {
             const rawId = (request && request.headers) ? request.headers[correlationIdHeader] : [];
             const correlationId = flatten<string | undefined>([rawId])[0] || "NO_CORRELATION_ID_FOUND";
 
-            const requestLogger = rootLogger.child({ correlationId });
+            const requestLogger = rootLogger.child({ correlationId, 'req-id': correlationId });
             if (options.postRequestCreate) {
               const newFields = options.postRequestCreate(requestLogger, request);
               requestLogger.fields = { ...requestLogger.fields, ...newFields };


### PR DESCRIPTION
This pull request adds `req-id` alongside `correlationId` in request loggers.

It implements the Pivotal Tracker story https://www.pivotaltracker.com/story/show/175415919
The other half is implemented in `data-api-v2` here: https://github.com/TrueRowing/data-api-v2/pull/813

These changes have already been published (for testing) as version `0.5.8` here:
https://npm.ops.hydrow-internal.net/#/detail/@hydrow/nestjs-bunyan